### PR TITLE
Update merging strategy 

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -745,12 +745,21 @@ async function run() {
         const currentYear = currentDate.getFullYear();
         const currentMonth = currentDate.getMonth() + 1; // Months are zero-based
 
-        // Calculate the branch name pattern for the current year and month
-        const branchPattern = `release/${currentYear}.${currentMonth}.`;
-
         const filteredBranches = branches.filter((branch) => {
-            // Check if the branch name starts with the current year and month pattern
-            return branch.name.startsWith(branchPattern);
+            // Extract the branch name
+            const branchName = branch.name;
+
+            // Extract the year and month from the branch name
+            const [year, month] = branchName.split('/')[1].split('.').map(Number);
+
+            // Calculate a numerical representation of the branch's release date
+            const branchReleaseDate = year * 10000 + month * 100;
+
+            // Calculate a numerical representation of the current date
+            const currentDateValue = currentYear * 10000 + currentMonth * 100;
+
+            // Check if the branch's release date is greater than or equal to the current date
+            return branchReleaseDate >= currentDateValue;
         });
 
         for (const branch of filteredBranches) {

--- a/index.js
+++ b/index.js
@@ -20,12 +20,21 @@ async function run() {
         const currentYear = currentDate.getFullYear();
         const currentMonth = currentDate.getMonth() + 1; // Months are zero-based
 
-        // Calculate the branch name pattern for the current year and month
-        const branchPattern = `release/${currentYear}.${currentMonth}.`;
-
         const filteredBranches = branches.filter((branch) => {
-            // Check if the branch name starts with the current year and month pattern
-            return branch.name.startsWith(branchPattern);
+            // Extract the branch name
+            const branchName = branch.name;
+
+            // Extract the year and month from the branch name
+            const [year, month] = branchName.split('/')[1].split('.').map(Number);
+
+            // Calculate a numerical representation of the branch's release date
+            const branchReleaseDate = year * 10000 + month * 100;
+
+            // Calculate a numerical representation of the current date
+            const currentDateValue = currentYear * 10000 + currentMonth * 100;
+
+            // Check if the branch's release date is greater than or equal to the current date
+            return branchReleaseDate >= currentDateValue;
         });
 
         for (const branch of filteredBranches) {


### PR DESCRIPTION
so we can update branches in our current month as well as any future branches we might have.

Ex:

release/2023.09.4.1 will propagate all changes down to release/2023.09.1.0

This will also propagate all changes forward to any future branches we might have
release/2023.10.1.2 will also receive the hotfix updates.

Even a new year's release will get the updates
release/2024.01.1.0 will get the hotfix updates

Explanation of the year + month math (`const branchReleaseDate = year * 10000 + month * 100;`)

Let's break it down step by step:

1. year and month are variables that store the extracted year and month components from the branch name, respectively. For example, if the branch name is release/2023.09.1.1, year would be 2023, and month would be 9.
2. year * 10000 is used to convert the year component into a four-digit number. In this case, 2023 becomes 20230000.
3. month * 100 is used to convert the month component into a two-digit number. In this case, 9 becomes 900.
4. Finally, year * 10000 + month * 100 combines the four-digit year and two-digit month to create a numerical representation of the branch's release date. In this example, it would result in 20230900.

The reason for this numerical representation is to make it easier to compare the branch's release date with the current date for filtering purposes. By converting both the branch's release date and the current date into numerical values, you can perform simple numeric comparisons to determine if a branch's release date is greater than or equal to the current date. This allows you to accurately filter branches based on their release dates.
